### PR TITLE
Sort groups by creation time

### DIFF
--- a/build/popup.js
+++ b/build/popup.js
@@ -19799,12 +19799,12 @@
 	    value: function refreshTabGroups() {
 	      var _this3 = this;
 
-	      this.db.groups.toArray(function (tabGroups) {
-	        _this3.setState({
-	          tabGroups: tabGroups.map(function (g) {
-	            return new _models.TabGroup(g);
-	          })
+	      this.db.groups.orderBy('createdAt').reverse().toArray(function (tabGroups) {
+	        tabGroups = tabGroups.map(function (g) {
+	          return new _models.TabGroup(g);
 	        });
+
+	        _this3.setState({ tabGroups: tabGroups });
 	      });
 	    }
 	  }, {

--- a/build/popup.js
+++ b/build/popup.js
@@ -24077,11 +24077,9 @@
 	      groups: 'uuid,createdAt' // indexed primary key
 	    }).upgrade(function (tx) {
 	      // Add a default date - we don't know when original groups were created
-	      tx.table('groups').toCollection().modify(function (g) {
-	        return g.createdAt = new Date();
-	      });
-	      tx.table('groups').toCollection().modify(function (g) {
-	        return g.updatedAt = new Date();
+	      tx.table('groups').toCollection().modify(function (groups) {
+	        groups.createdAt = new Date();
+	        groups.updatedAt = new Date();
 	      });
 	    });
 	    return _this;

--- a/build/popup.js
+++ b/build/popup.js
@@ -19889,12 +19889,16 @@
 	    var uuid = _ref$uuid === undefined ? _nodeUuid2.default.v4() : _ref$uuid;
 	    var name = _ref.name;
 	    var tabs = _ref.tabs;
+	    var createdAt = _ref.createdAt;
+	    var updatedAt = _ref.updatedAt;
 
 	    _classCallCheck(this, TabGroup);
 
 	    this.uuid = uuid;
 	    this.name = name;
 	    this.tabs = tabs;
+	    this.createdAt = createdAt ? Date.parse(createdAt) : new Date();
+	    this.updatedAt = updatedAt ? Date.parse(updatedAt) : new Date();
 	  }
 
 	  /**
@@ -19925,7 +19929,9 @@
 	        db.groups.add({
 	          uuid: _this.uuid,
 	          name: _this.name,
-	          tabs: _this.tabs
+	          tabs: _this.tabs,
+	          createdAt: _this.createdAt,
+	          updatedAt: new Date()
 	        }).then(function () {
 	          chrome.runtime.sendMessage(_constants2.default.CHANGE);
 	          resolve(_this);
@@ -24065,6 +24071,18 @@
 
 	    _this.version(1).stores({
 	      groups: 'uuid' // indexed primary key
+	    });
+
+	    _this.version(2).stores({
+	      groups: 'uuid,createdAt' // indexed primary key
+	    }).upgrade(function (tx) {
+	      // Add a default date - we don't know when original groups were created
+	      tx.table('groups').toCollection().modify(function (g) {
+	        return g.createdAt = new Date();
+	      });
+	      tx.table('groups').toCollection().modify(function (g) {
+	        return g.updatedAt = new Date();
+	      });
 	    });
 	    return _this;
 	  }

--- a/src/components/views/popup.jsx
+++ b/src/components/views/popup.jsx
@@ -43,10 +43,10 @@ export class Popup extends React.Component {
    * Fetch tabGroups from storage and update component state
    */
   refreshTabGroups() {
-    this.db.groups.toArray((tabGroups) => {
-      this.setState({
-        tabGroups: tabGroups.map(g => new TabGroup(g))
-      })
+    this.db.groups.orderBy('createdAt').reverse().toArray((tabGroups) => {
+      tabGroups = tabGroups.map(g => new TabGroup(g));
+
+      this.setState({ tabGroups })
     });
   }
 

--- a/src/database.js
+++ b/src/database.js
@@ -11,6 +11,15 @@ export class Database extends Dexie {
       .stores({
         groups: 'uuid' // indexed primary key
       });
+
+    this.version(2)
+      .stores({
+        groups: 'uuid,createdAt' // indexed primary key
+      }).upgrade(tx => {
+        // Add a default date - we don't know when original groups were created
+        tx.table('groups').toCollection().modify(g => g.createdAt = new Date());
+        tx.table('groups').toCollection().modify(g => g.updatedAt = new Date());
+      });
   }
 
 }

--- a/src/database.js
+++ b/src/database.js
@@ -17,8 +17,10 @@ export class Database extends Dexie {
         groups: 'uuid,createdAt' // indexed primary key
       }).upgrade(tx => {
         // Add a default date - we don't know when original groups were created
-        tx.table('groups').toCollection().modify(g => g.createdAt = new Date());
-        tx.table('groups').toCollection().modify(g => g.updatedAt = new Date());
+        tx.table('groups').toCollection().modify(groups => {
+          groups.createdAt = new Date();
+          groups.updatedAt = new Date();
+        });
       });
   }
 

--- a/src/models/tab-group.js
+++ b/src/models/tab-group.js
@@ -12,10 +12,12 @@ export class TabGroup {
 
   tabs;
 
-  constructor({ uuid = UUID.v4(), name, tabs }) {
+  constructor({ uuid = UUID.v4(), name, tabs, createdAt, updatedAt }) {
     this.uuid = uuid;
     this.name = name;
     this.tabs = tabs;
+    this.createdAt = (createdAt) ? Date.parse(createdAt) : new Date();
+    this.updatedAt = (updatedAt) ? Date.parse(updatedAt) : new Date();
   }
 
   /**
@@ -37,7 +39,9 @@ export class TabGroup {
       db.groups.add({
         uuid: this.uuid,
         name: this.name,
-        tabs: this.tabs
+        tabs: this.tabs,
+        createdAt: this.createdAt,
+        updatedAt: new Date()
       })
         .then(() => {
           chrome.runtime.sendMessage(constants.CHANGE);


### PR DESCRIPTION
Addresses #3 

Introduces two new stored attributes on the tab group - `createdAt` (indexed) and `updatedAt` (not indexed)

The list of tab groups is sorted by `createdAt` in descending order when the popup is viewed.
