### PR TITLE
Add option to handle file links

### DIFF
--- a/src/services/window-service.ts
+++ b/src/services/window-service.ts
@@ -1,62 +1,62 @@
 import * as browser from "webextension-polyfill";
 
 class WindowService {
-    /**
-     * Get a list of all currently open, regular windows
-     */
-    static getAllWindows(): Promise<browser.Windows.Window[]> {
-        return new Promise((resolve, reject) => {
-            browser.windows
-                .getAll({ windowTypes: ["normal"] })
-                .then(resolve)
-                .catch(reject);
+  /**
+   * Get a list of all currently open, regular windows
+   */
+  static getAllWindows(): Promise<browser.Windows.Window[]> {
+    return new Promise((resolve, reject) => {
+      browser.windows
+        .getAll({ windowTypes: ["normal"] })
+        .then(resolve)
+        .catch(reject);
+    });
+  }
+
+  /**
+   * Get the currently focused window
+   */
+  static getCurrentWindow(): Promise<browser.Windows.Window> {
+    return new Promise((resolve, reject) => {
+      browser.windows
+        .getCurrent({ populate: true })
+        .then(resolve)
+        .catch(reject);
+    });
+  }
+
+  /**
+   * Create a new window with tabs for the specified list of urls
+   */
+  static createWindow(urls: string[]): Promise<browser.Windows.Window> {
+    return new Promise((resolve, reject) => {
+    	let sanitized = urls.map((url) => {
+        	if (url.startsWith("file")) {
+        		url = url.replace("file://", "");
+            	return `http://localhost:3000/?path=${url}`;
+        	}
+        	return url;
         });
-    }
 
-    /**
-     * Get the currently focused window
-     */
-    static getCurrentWindow(): Promise<browser.Windows.Window> {
-        return new Promise((resolve, reject) => {
-            browser.windows
-                .getCurrent({ populate: true })
-                .then(resolve)
-                .catch(reject);
-        });
-    }
+        const payload = {
+        	url: sanitized,
+        };
 
-    /**
-     * Create a new window with tabs for the specified list of urls
-     */
-    static createWindow(urls: string[]): Promise<browser.Windows.Window> {
-        return new Promise((resolve, reject) => {
-            let sanitized = urls.map((url) => {
-                if (url.startsWith("file")) {
-                    url = url.replace("file://", "");
-                    return `http://localhost:3000/?path=${url}`;
-                }
-                return url;
-            });
+        browser.windows.create(payload).then(resolve).catch(reject);
+    });
+  }
 
-            const payload = {
-                url: sanitized,
-            };
-
-            browser.windows.create(payload).then(resolve).catch(reject);
-        });
-    }
-
-    /**
-     * Close the specified window
-     */
-    static closeWindow(id: number): Promise<void> {
-        return new Promise((resolve, reject) => {
-            browser.windows
-                .remove(id)
-                .then(() => resolve(undefined))
-                .catch(reject);
-        });
-    }
+  /**
+   * Close the specified window
+   */
+  static closeWindow(id: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      browser.windows
+        .remove(id)
+        .then(() => resolve(undefined))
+        .catch(reject);
+    });
+  }
 }
 
 export default WindowService;

--- a/src/services/window-service.ts
+++ b/src/services/window-service.ts
@@ -1,54 +1,62 @@
 import * as browser from "webextension-polyfill";
 
 class WindowService {
-  /**
-   * Get a list of all currently open, regular windows
-   */
-  static getAllWindows(): Promise<browser.Windows.Window[]> {
-    return new Promise((resolve, reject) => {
-      browser.windows
-        .getAll({ windowTypes: ["normal"] })
-        .then(resolve)
-        .catch(reject);
-    });
-  }
+    /**
+     * Get a list of all currently open, regular windows
+     */
+    static getAllWindows(): Promise<browser.Windows.Window[]> {
+        return new Promise((resolve, reject) => {
+            browser.windows
+                .getAll({ windowTypes: ["normal"] })
+                .then(resolve)
+                .catch(reject);
+        });
+    }
 
-  /**
-   * Get the currently focused window
-   */
-  static getCurrentWindow(): Promise<browser.Windows.Window> {
-    return new Promise((resolve, reject) => {
-      browser.windows
-        .getCurrent({ populate: true })
-        .then(resolve)
-        .catch(reject);
-    });
-  }
+    /**
+     * Get the currently focused window
+     */
+    static getCurrentWindow(): Promise<browser.Windows.Window> {
+        return new Promise((resolve, reject) => {
+            browser.windows
+                .getCurrent({ populate: true })
+                .then(resolve)
+                .catch(reject);
+        });
+    }
 
-  /**
-   * Create a new window with tabs for the specified list of urls
-   */
-  static createWindow(urls: string[]): Promise<browser.Windows.Window> {
-    return new Promise((resolve, reject) => {
-      const payload = {
-        url: urls,
-      };
+    /**
+     * Create a new window with tabs for the specified list of urls
+     */
+    static createWindow(urls: string[]): Promise<browser.Windows.Window> {
+        return new Promise((resolve, reject) => {
+            let sanitized = urls.map((url) => {
+                if (url.startsWith("file")) {
+                    url = url.replace("file://", "");
+                    return `http://localhost:3000/?path=${url}`;
+                }
+                return url;
+            });
 
-      browser.windows.create(payload).then(resolve).catch(reject);
-    });
-  }
+            const payload = {
+                url: sanitized,
+            };
 
-  /**
-   * Close the specified window
-   */
-  static closeWindow(id: number): Promise<void> {
-    return new Promise((resolve, reject) => {
-      browser.windows
-        .remove(id)
-        .then(() => resolve(undefined))
-        .catch(reject);
-    });
-  }
+            browser.windows.create(payload).then(resolve).catch(reject);
+        });
+    }
+
+    /**
+     * Close the specified window
+     */
+    static closeWindow(id: number): Promise<void> {
+        return new Promise((resolve, reject) => {
+            browser.windows
+                .remove(id)
+                .then(() => resolve(undefined))
+                .catch(reject);
+        });
+    }
 }
 
 export default WindowService;


### PR DESCRIPTION
Hi there, thanks for making this extension!

I noticed that you cannot restore windows that have `file://` links in any of the tabs.

After looking through the code it seems that the browser (I'm using firefox) blocks the loading of `file://` links 
when using the `browser.tabs` or `browser.windows` APIs. 

As a solution to this, I added a little code that would modify URL of any `file://` link and instead redirect it to a
program running locally that can then handle and display the file.

I realize this is not the best approach (especially hardcoding the port) so I was wondering if you had any ideas on how this feature could be implemented without hardcoded defaults. Maybe a field in the options page?

Thanks.